### PR TITLE
[FIX] Don't copy Avalara partner code as it has a uniqueness constraint

### DIFF
--- a/avalara_salestax/models/res_partner.py
+++ b/avalara_salestax/models/res_partner.py
@@ -29,7 +29,7 @@ class ResPartner(models.Model):
     validated_on_save = fields.Boolean(
         'Validated On Save',
         help='Indicates if the address was validated automatically')
-    customer_code = fields.Char('Avalara Customer Code')
+    customer_code = fields.Char('Avalara Customer Code', copy=False)
     tax_apply = fields.Boolean(
         'Tax Calculation',
         help='Indicates that AvaTax calculation is compulsory')


### PR DESCRIPTION
Just a small bug I encountered when I was running a test: I could not copy a partner that had this code set.